### PR TITLE
libFuzzer does not allow to use LLVMFuzzerMutate from CustomCrossover so

### DIFF
--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -493,10 +493,12 @@ void Mutator::CrossOver(const protobuf::Message& message1,
     assert(message2->IsInitialized());
   }
 
-  if (MessageDifferencer::Equals(*message2_copy, *message2) ||
-      MessageDifferencer::Equals(message1, *message2)) {
-    Mutate(message2, 0);
-  }
+  // Can't call mutate from crossover because of a bug in libFuzzer.
+  return;
+  // if (MessageDifferencer::Equals(*message2_copy, *message2) ||
+  //     MessageDifferencer::Equals(message1, *message2)) {
+  //   Mutate(message2, 0);
+  // }
 }
 
 void Mutator::CrossOverImpl(const protobuf::Message& message1,

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -555,6 +555,7 @@ TYPED_TEST(MutatorTypedTest, CrossOverRepeatedMessages) {
 
 TYPED_TEST(MutatorTypedTest, FailedMutations) {
   TestMutator mutator(false);
+  size_t crossovers = 0;
   for (int i = 0; i < 10000; ++i) {
     typename TestFixture::Message messages[2];
     typename TestFixture::Message tmp;
@@ -569,8 +570,13 @@ TYPED_TEST(MutatorTypedTest, FailedMutations) {
 
     tmp.CopyFrom(messages[1]);
     mutator.CrossOver(messages[0], &tmp);
-    EXPECT_FALSE(MessageDifferencer::Equals(tmp, messages[1]));
+    if (MessageDifferencer::Equals(tmp, messages[1]) ||
+        MessageDifferencer::Equals(tmp, messages[0]))
+      ++crossovers;
   }
+
+  // CrossOver may fail but very rare.
+  EXPECT_LT(crossovers, 100);
 }
 
 TYPED_TEST(MutatorTypedTest, Size) {


### PR DESCRIPTION
we need temporarily undo 142e08bf2a34d57d72e4619adeea4d7bab81a7d0