### PR TITLE
Fix compile error in with -Wstring-conversion by changing error message in assertion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,7 +62,7 @@ set(CMAKE_REQUIRED_FLAGS "-fsanitize-coverage=trace-cmp")
 check_cxx_compiler_flag(-fsanitize-coverage=trace-cmp LIB_PROTO_MUTATOR_HAS_TRACE_CMP)
 unset(CMAKE_REQUIRED_FLAGS)
 
-set(EXTRA_FLAGS "-fno-exceptions -Werror -Wall")
+set(EXTRA_FLAGS "-fno-exceptions -Werror -Wall -Wstring-conversion")
 
 if (LIB_PROTO_MUTATOR_WITH_ASAN)
   if (LIB_PROTO_MUTATOR_HAS_SANITIZE_ADDRESS)

--- a/src/field_instance.h
+++ b/src/field_instance.h
@@ -420,7 +420,7 @@ struct FieldFunction {
             ->template ForType<std::unique_ptr<protobuf::Message>>(field,
                                                                    args...);
     }
-    assert(!"Unknown type");
+    assert(false && "Unknown type");
     abort();
   }
 };


### PR DESCRIPTION
Change assertion so that it doesn't cause a compilation error with
"-Wstring-conversion" compile flag. Add "-Wstring-conversion" to CMakeLists.txt
so that similar mistakes in the future will be caught here, rather than 
downstream.