### PR TITLE
Add flag for tests building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ project(LibProtobufMutator CXX)
 enable_language(C)
 enable_language(CXX)
 
+option(TESTING "Enable test building" ON)
 option(LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF
        "Automatically download working protobuf" OFF)
 option(LIB_PROTO_MUTATOR_WITH_ASAN "Enable address sanitizer" OFF)
@@ -110,15 +111,19 @@ else()
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-enable_testing()
+if (TESTING)
+  enable_testing()
+  find_package(GTest)
+  if (NOT GTEST_FOUND)
+    include(googletest)
+  endif()
 
-include(googletest)
-
-if (NOT LIB_PROTO_MUTATOR_CTEST_JOBS)
-  ProcessorCount(LIB_PROTO_MUTATOR_CTEST_JOBS)
+  if (NOT LIB_PROTO_MUTATOR_CTEST_JOBS)
+    ProcessorCount(LIB_PROTO_MUTATOR_CTEST_JOBS)
+  endif()
+  add_custom_target(check
+                    COMMAND ${CMAKE_CTEST_COMMAND} -j${LIB_PROTO_MUTATOR_CTEST_JOBS} --output-on-failure)
 endif()
-add_custom_target(check
-                  COMMAND ${CMAKE_CTEST_COMMAND} -j${LIB_PROTO_MUTATOR_CTEST_JOBS} --output-on-failure)
 
 add_subdirectory(src)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ project(LibProtobufMutator CXX)
 enable_language(C)
 enable_language(CXX)
 
-option(TESTING "Enable test building" ON)
+option(LIB_PROTO_MUTATOR_TESTING "Enable test building" ON)
 option(LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF
        "Automatically download working protobuf" OFF)
 option(LIB_PROTO_MUTATOR_WITH_ASAN "Enable address sanitizer" OFF)
@@ -111,7 +111,7 @@ else()
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
-if (TESTING)
+if (LIB_PROTO_MUTATOR_TESTING)
   enable_testing()
 
   set(LIB_DIR "lib${LIB_SUFFIX}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,10 +113,7 @@ endif()
 
 if (TESTING)
   enable_testing()
-  find_package(GTest)
-  if (NOT GTEST_FOUND)
-    include(googletest)
-  endif()
+  include(googletest)
 
   if (NOT LIB_PROTO_MUTATOR_CTEST_JOBS)
     ProcessorCount(LIB_PROTO_MUTATOR_CTEST_JOBS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -24,31 +24,33 @@ target_link_libraries(protobuf-mutator
 set_property(TARGET protobuf-mutator
              PROPERTY COMPILE_FLAGS "${NO_FUZZING_FLAGS}")
 
-protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
-                      mutator_test_proto2.proto
-                      mutator_test_proto3.proto)
+if (TESTING)
+  protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS
+                        mutator_test_proto2.proto
+                        mutator_test_proto3.proto)
 
-add_executable(mutator_test
-               mutator_test.cc
-               utf8_fix_test.cc
-               weighted_reservoir_sampler_test.cc
-               ${PROTO_SRCS})
-target_link_libraries(mutator_test
-                      protobuf-mutator
-                      ${ZLIB_LIBRARIES}
-                      ${GTEST_BOTH_LIBRARIES}
-                      ${CMAKE_THREAD_LIBS_INIT})
+  add_executable(mutator_test
+                 mutator_test.cc
+                 utf8_fix_test.cc
+                 weighted_reservoir_sampler_test.cc
+                 ${PROTO_SRCS})
+  target_link_libraries(mutator_test
+                        protobuf-mutator
+                        ${ZLIB_LIBRARIES}
+                        ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT})
 
-ProcessorCount(CPU_COUNT)
-math(EXPR TEST_SHARDS_COUNT 2*${CPU_COUNT})
-math(EXPR TEST_SHARDS_MAX ${TEST_SHARDS_COUNT}-1)
-foreach(SHARD RANGE ${TEST_SHARDS_MAX})
-  add_test(test.protobuf_mutator_test_${SHARD} mutator_test --gtest_color=yes AUTO)
-  set_property(
-      TEST test.protobuf_mutator_test_${SHARD}
-      APPEND PROPERTY ENVIRONMENT
-      GTEST_SHARD_INDEX=${SHARD}
-      GTEST_TOTAL_SHARDS=${TEST_SHARDS_COUNT})
-endforeach(SHARD)
+  ProcessorCount(CPU_COUNT)
+  math(EXPR TEST_SHARDS_COUNT 2*${CPU_COUNT})
+  math(EXPR TEST_SHARDS_MAX ${TEST_SHARDS_COUNT}-1)
+  foreach(SHARD RANGE ${TEST_SHARDS_MAX})
+    add_test(test.protobuf_mutator_test_${SHARD} mutator_test --gtest_color=yes AUTO)
+    set_property(
+        TEST test.protobuf_mutator_test_${SHARD}
+        APPEND PROPERTY ENVIRONMENT
+        GTEST_SHARD_INDEX=${SHARD}
+        GTEST_TOTAL_SHARDS=${TEST_SHARDS_COUNT})
+  endforeach(SHARD)
 
-add_dependencies(check mutator_test)
+  add_dependencies(check mutator_test)
+endif()


### PR DESCRIPTION
`TESTING` option can enable/disable builds of test so the project can be used as a library without redundant compilations
Also I've add `find_package(GTest)` line (maybe even delete cmake/external/googletest.cmake?), without it I cannot build:
`No rule to make target 'external.googletest/lib/libgtest.a', needed by 'src/mutator_test'.  Stop.`