### PR TITLE
Added custom field mutators.

### DIFF
--- a/src/field_instance.h
+++ b/src/field_instance.h
@@ -183,14 +183,14 @@ class ConstFieldInstance {
                protobuf::FileDescriptor::SYNTAX_PROTO3;
   }
 
+  const protobuf::FieldDescriptor* descriptor() const { return descriptor_; }
+
  protected:
   bool is_repeated() const { return descriptor_->is_repeated(); }
 
   const protobuf::Reflection& reflection() const {
     return *message_->GetReflection();
   }
-
-  const protobuf::FieldDescriptor* descriptor() const { return descriptor_; }
 
   size_t index() const { return index_; }
 

--- a/src/libfuzzer/libfuzzer_macro.cc
+++ b/src/libfuzzer/libfuzzer_macro.cc
@@ -181,5 +181,11 @@ bool LoadProtoInput(bool binary, const uint8_t* data, size_t size,
                 : ParseTextMessage(data, size, input);
 }
 
+void RegisterProtoFieldMutator(
+    const protobuf::FieldDescriptor* field,
+    std::function<void(protobuf::Message*)> callback) {
+  protobuf_mutator::Mutator::RegisterCustomMutation(field, callback);
+}
+
 }  // namespace libfuzzer
 }  // namespace protobuf_mutator

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -218,6 +218,7 @@ class TestMutator : public Mutator {
  public:
   explicit TestMutator(bool keep_initialized) : Mutator(&random_), random_(17) {
     keep_initialized_ = keep_initialized;
+    custom_mutations_.clear();
   }
 
   // Avoids dedup logic for some tests.
@@ -575,6 +576,43 @@ TYPED_TEST(MutatorTypedTest, FailedMutations) {
 
   // CrossOver may fail but very rare.
   EXPECT_LT(crossovers, 100u);
+}
+
+TYPED_TEST(MutatorTypedTest, FieldMutator) {
+  constexpr char kInitialString[] = " ";
+  constexpr char kIndicatorString[] = "0123456789abcdef";
+  bool custom_mutation = false;
+  bool regular_mutation = false;
+
+  const protobuf::Descriptor* descriptor =
+    (typename TestFixture::Message()).GetDescriptor();
+  TestMutator mutator(false);
+  TestMutator::RegisterCustomMutation(
+      descriptor->FindFieldByName("optional_string"),
+      [kIndicatorString](protobuf::Message* message){
+        typename TestFixture::Message* test_message =
+            dynamic_cast<typename TestFixture::Message*>(message);
+        test_message->set_optional_string(kIndicatorString);
+      });
+
+  for (int j = 0; j < 100000; ++j) {
+    // Include this field to increase the probability of mutation.
+    typename TestFixture::Message message;
+    message.set_optional_string(kInitialString);
+    mutator.Mutate(&message, 1000);
+
+    if (message.optional_string() == kIndicatorString) {
+      custom_mutation = true;
+    } else if (message.optional_string() != kInitialString) {
+      regular_mutation = true;
+    }
+
+    if (custom_mutation && regular_mutation)
+      break;
+  }
+
+  EXPECT_TRUE(custom_mutation);
+  EXPECT_TRUE(regular_mutation);
 }
 
 TYPED_TEST(MutatorTypedTest, Serialization) {


### PR DESCRIPTION
This adds support for users of libprotobuf-mutator to supply per-field custom mutations in the form of a callback that can operate on the parent message.