### PR TITLE
[NFC] Change types for in uniform_int_distribution for Windows

### DIFF
--- a/src/libfuzzer/libfuzzer_mutator.cc
+++ b/src/libfuzzer/libfuzzer_mutator.cc
@@ -55,7 +55,9 @@ double Mutator::MutateDouble(double value) { return MutateValue(value); }
 std::string Mutator::MutateString(const std::string& value,
                                   size_t size_increase_hint) {
   // Randomly return empty strings as LLVMFuzzerMutate does not produce them.
-  if (!std::uniform_int_distribution<uint8_t>(0, 20)(*random())) return {};
+  // Use uint16_t because on Windows, uniform_int_distribution does not support
+  // any 8 bit types.
+  if (!std::uniform_int_distribution<uint16_t>(0, 20)(*random())) return {};
   std::string result = value;
   result.resize(value.size() + size_increase_hint);
   if (result.empty()) result.push_back(0);

--- a/src/utf8_fix.cc
+++ b/src/utf8_fix.cc
@@ -47,7 +47,9 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
     case 2:
       c &= 0x7FF;
       if (c < 0x80) {
-        c = std::uniform_int_distribution<char32_t>(0x80, 0x7FF)(*random);
+        // Use int32_t because uniform_int_distribution does not support
+        // char32_t on Windows.
+        c = std::uniform_int_distribution<int32_t>(0x80, 0x7FF)(*random);
       }
       StoreCode(b, c, size, 0xC0);
       break;
@@ -57,8 +59,8 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
       // [0xD800, 0xE000) are reserved for UTF-16 surrogate halves.
       if (c < 0x800 || (c >= 0xD800 && c < 0xE000)) {
         uint32_t halves = 0xE000 - 0xD800;
-        c = std::uniform_int_distribution<char32_t>(0x800,
-                                                    0xFFFF - halves)(*random);
+        c = std::uniform_int_distribution<int32_t>(0x800,
+						    0xFFFF - halves)(*random);
         if (c >= 0xD800) c += halves;
       }
       StoreCode(b, c, size, 0xE0);
@@ -66,7 +68,7 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
     case 4:
       c &= 0x1FFFFF;
       if (c < 0x10000 || c > 0x10FFFF) {
-        c = std::uniform_int_distribution<char32_t>(0x10000, 0x10FFFF)(*random);
+        c = std::uniform_int_distribution<int32_t>(0x10000, 0x10FFFF)(*random);
       }
       StoreCode(b, c, size, 0xF0);
       break;

--- a/src/utf8_fix.cc
+++ b/src/utf8_fix.cc
@@ -47,9 +47,9 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
     case 2:
       c &= 0x7FF;
       if (c < 0x80) {
-        // Use int32_t because uniform_int_distribution does not support
+        // Use uint32_t because uniform_int_distribution does not support
         // char32_t on Windows.
-        c = std::uniform_int_distribution<int32_t>(0x80, 0x7FF)(*random);
+        c = std::uniform_int_distribution<uint32_t>(0x80, 0x7FF)(*random);
       }
       StoreCode(b, c, size, 0xC0);
       break;
@@ -59,8 +59,8 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
       // [0xD800, 0xE000) are reserved for UTF-16 surrogate halves.
       if (c < 0x800 || (c >= 0xD800 && c < 0xE000)) {
         uint32_t halves = 0xE000 - 0xD800;
-        c = std::uniform_int_distribution<int32_t>(0x800,
-                                                   0xFFFF - halves)(*random);
+        c = std::uniform_int_distribution<uint32_t>(0x800,
+                                                    0xFFFF - halves)(*random);
         if (c >= 0xD800) c += halves;
       }
       StoreCode(b, c, size, 0xE0);
@@ -68,7 +68,7 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
     case 4:
       c &= 0x1FFFFF;
       if (c < 0x10000 || c > 0x10FFFF) {
-        c = std::uniform_int_distribution<int32_t>(0x10000, 0x10FFFF)(*random);
+        c = std::uniform_int_distribution<uint32_t>(0x10000, 0x10FFFF)(*random);
       }
       StoreCode(b, c, size, 0xF0);
       break;

--- a/src/utf8_fix.cc
+++ b/src/utf8_fix.cc
@@ -60,7 +60,7 @@ char* FixCode(char* b, const char* e, RandomEngine* random) {
       if (c < 0x800 || (c >= 0xD800 && c < 0xE000)) {
         uint32_t halves = 0xE000 - 0xD800;
         c = std::uniform_int_distribution<int32_t>(0x800,
-						    0xFFFF - halves)(*random);
+                                                   0xFFFF - halves)(*random);
         if (c >= 0xD800) c += halves;
       }
       StoreCode(b, c, size, 0xE0);


### PR DESCRIPTION
On Windows std::uniform_int_distribution does not accept uint8_t or
char32_t. Using them causes compilation failure.
In places where they are used, substitute uint16_t and char32_t,
respectively.
This patch should not change any functionality.