### PR TITLE
Several cmake fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(LIB_PROTO_MUTATOR_TESTING "Enable test building" ON)
 option(LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF
        "Automatically download working protobuf" OFF)
 option(LIB_PROTO_MUTATOR_WITH_ASAN "Enable address sanitizer" OFF)
+option(PKG_CONFIG_PATH "Directory to install pkgconfig file" "share/pkgconfig")
 set(LIB_PROTO_MUTATOR_FUZZER_LIBRARIES "" CACHE STRING "Fuzzing engine libs")
 
 # External dependencies
@@ -134,6 +135,6 @@ endif()
 
 configure_file("libprotobuf-mutator.pc.in" "libprotobuf-mutator.pc" @ONLY)
 install(FILES "${CMAKE_BINARY_DIR}/libprotobuf-mutator.pc"
-  DESTINATION share/pkgconfg)
+  DESTINATION ${PKG_CONFIG_PATH})
 install(DIRECTORY ./port ./src DESTINATION include/libprotobuf-mutator
   FILES_MATCHING PATTERN "*.h")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -21,8 +21,9 @@ add_library(protobuf-mutator
             utf8_fix.cc)
 target_link_libraries(protobuf-mutator
                       ${PROTOBUF_LIBRARIES})
-set_property(TARGET protobuf-mutator
-             PROPERTY COMPILE_FLAGS "${NO_FUZZING_FLAGS}")
+set_target_properties(protobuf-mutator PROPERTIES
+                      COMPILE_FLAGS "${NO_FUZZING_FLAGS}"
+                      SOVERSION 0)
 
 if (LIB_PROTO_MUTATOR_TESTING)
   protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -55,4 +55,6 @@ if (LIB_PROTO_MUTATOR_TESTING)
   add_dependencies(check mutator_test)
 endif()
 
-install(TARGETS protobuf-mutator ARCHIVE DESTINATION ${LIB_DIR})
+install(TARGETS protobuf-mutator
+        ARCHIVE DESTINATION ${LIB_DIR}
+        LIBRARY DESTINATION ${LIB_DIR})

--- a/src/libfuzzer/CMakeLists.txt
+++ b/src/libfuzzer/CMakeLists.txt
@@ -21,4 +21,6 @@ target_link_libraries(protobuf-mutator-libfuzzer
 set_property(TARGET protobuf-mutator-libfuzzer
              PROPERTY COMPILE_FLAGS "${NO_FUZZING_FLAGS}")
 
-install(TARGETS protobuf-mutator-libfuzzer ARCHIVE DESTINATION ${LIB_DIR})
+install(TARGETS protobuf-mutator-libfuzzer
+        ARCHIVE DESTINATION ${LIB_DIR}
+        LIBRARY DESTINATION ${LIB_DIR})

--- a/src/libfuzzer/CMakeLists.txt
+++ b/src/libfuzzer/CMakeLists.txt
@@ -18,8 +18,9 @@ add_library(protobuf-mutator-libfuzzer
 target_link_libraries(protobuf-mutator-libfuzzer
                       protobuf-mutator
                       ${PROTOBUF_LIBRARIES})
-set_property(TARGET protobuf-mutator-libfuzzer
-             PROPERTY COMPILE_FLAGS "${NO_FUZZING_FLAGS}")
+set_target_properties(protobuf-mutator-libfuzzer PROPERTIES
+                      COMPILE_FLAGS "${NO_FUZZING_FLAGS}"
+                      SOVERSION 0)
 
 install(TARGETS protobuf-mutator-libfuzzer
         ARCHIVE DESTINATION ${LIB_DIR}


### PR DESCRIPTION
This PR contains several fixes for `CMakeLists.txt` files for the following issues:

* Shared libraries were not installed due to lack of `LIBRARY DESTINATION` option in `install` command.
* `SOVERSION` was not set up, so only `.so` files were created, but `.so.*` were missing.
* Installation path for pkgconfig file had a typo and was not configurable (some Linux distributions prefer to use `/usr/lib(64)/pkgconfig` instead of `/usr/share/pkgconfig`).