### PR TITLE
Move LIB_DIR var outside of testing related if statement.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,10 @@ else()
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 endif()
 
+set(LIB_DIR "lib${LIB_SUFFIX}")
+
 if (LIB_PROTO_MUTATOR_TESTING)
   enable_testing()
-
-  set(LIB_DIR "lib${LIB_SUFFIX}")
 
   include(googletest)
 


### PR DESCRIPTION
LIB_DIR is used by make install to set the install path of the static
libraries. It needs to be set even when testing is disabled.