### PR TITLE
Speedup unit tests

### DIFF
--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -370,13 +370,12 @@ class FieldMutator {
   }
 
   void Mutate(bool* value) const {
-    RepeatMutate(value, std::bind(&Mutator::MutateBool, mutator_, _1), 2);
+    RepeatMutate(value, std::bind(&Mutator::MutateBool, mutator_, _1));
   }
 
   void Mutate(FieldInstance::Enum* value) const {
     RepeatMutate(&value->index,
-                 std::bind(&Mutator::MutateEnum, mutator_, _1, value->count),
-                 std::max<size_t>(value->count, 1));
+                 std::bind(&Mutator::MutateEnum, mutator_, _1, value->count));
     assert(value->index < value->count);
   }
 
@@ -393,16 +392,16 @@ class FieldMutator {
   void Mutate(std::unique_ptr<Message>* message) const {
     assert(!enforce_changes_);
     assert(*message);
-    if (GetRandomBool(mutator_->random(), 100)) return;
+    if (GetRandomBool(mutator_->random(), mutator_->random_to_default_ratio_))
+      return;
     mutator_->Mutate(message->get(), size_increase_hint_);
   }
 
  private:
   template <class T, class F>
-  void RepeatMutate(T* value, F mutate,
-                    size_t unchanged_one_out_of = 100) const {
+  void RepeatMutate(T* value, F mutate) const {
     if (!enforce_changes_ &&
-        GetRandomBool(mutator_->random(), unchanged_one_out_of)) {
+        GetRandomBool(mutator_->random(), mutator_->random_to_default_ratio_)) {
       return;
     }
     T tmp = *value;

--- a/src/mutator.h
+++ b/src/mutator.h
@@ -100,6 +100,7 @@ class Mutator {
   bool ApplyCustomMutations(protobuf::Message* message,
                             const protobuf::FieldDescriptor* field);
   bool keep_initialized_ = true;
+  size_t random_to_default_ratio_ = 100;
   RandomEngine* random_;
 };
 


### PR DESCRIPTION
Reduce mutations space by using default values more frequently in tests.
Some tests run 100x times faster now.