### PR TITLE
Fix compile error/warning in src/field_instance.h

### DIFF
--- a/src/field_instance.h
+++ b/src/field_instance.h
@@ -146,7 +146,7 @@ class ConstFieldInstance {
             : reflection().GetEnum(*message_, descriptor_);
     *value = {static_cast<size_t>(value_descriptor->index()),
               static_cast<size_t>(value_descriptor->type()->value_count())};
-    if (value->index < 0 || value->index >= value->count) GetDefault(value);
+    if (value->index >= value->count) GetDefault(value);
   }
 
   void Load(std::string* value) const {


### PR DESCRIPTION
it was a comparison with unsigned < 0, which is always false.

The error previously was:
[12/16] Building CXX object src/CMakeFiles/protobuf-mutator.dir/mutator.cc.oIn file included from /fuzzing/libprotobuf-mutator/src/mutator.cc:23:/fuzzing/libprotobuf-mutator/src/field_instance.h:149:22: warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]    if (value->index < 0 || value->index >= value->count) GetDefault(value);        ~~~~~~~~~~~~ ^ ~1 warning generated.