### PR TITLE
Updates CMakeLists.txt to build for MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -46,6 +46,21 @@ set(CMAKE_CXX_STANDARD 11)
 
 include_directories(${PROJECT_SOURCE_DIR})
 
+if (MSVC)
+  option(LIB_PROTO_MUTATOR_MSVC_STATIC_RUNTIME "Link static runtime libraries" ON)
+  if (LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF OR LIB_PROTO_MUTATOR_MSVC_STATIC_RUNTIME)
+    # This is the default for protobuf with MSVC
+    # http://www.cmake.org/Wiki/CMake_FAQ#How_can_I_build_my_MSVC_application_with_a_static_runtime.3F
+    foreach(flag_var
+        CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE
+        CMAKE_CXX_FLAGS_MINSIZEREL CMAKE_CXX_FLAGS_RELWITHDEBINFO)
+      if(${flag_var} MATCHES "/MD")
+        string(REGEX REPLACE "/MD" "/MT" ${flag_var} "${${flag_var}}")
+      endif(${flag_var} MATCHES "/MD")
+    endforeach(flag_var)
+  endif (LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF OR LIB_PROTO_MUTATOR_MSVC_STATIC_RUNTIME)
+endif (MSVC)
+
 set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
 check_cxx_compiler_flag(-fsanitize=address LIB_PROTO_MUTATOR_HAS_SANITIZE_ADDRESS)
 check_cxx_compiler_flag("-fsanitize=address -fsanitize-address-use-after-scope"
@@ -66,10 +81,12 @@ unset(CMAKE_REQUIRED_FLAGS)
 
 check_cxx_compiler_flag(-Wstring-conversion LIB_PROTO_MUTATOR_HAS_WSTRING_CONVERSION)
 
-set(EXTRA_FLAGS "-fno-exceptions -Werror -Wall")
-if (LIB_PROTO_MUTATOR_HAS_WSTRING_CONVERSION)
-  set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wstring-conversion")
-endif()
+if (NOT MSVC)
+  set(EXTRA_FLAGS "-fno-exceptions -Werror -Wall")
+  if (LIB_PROTO_MUTATOR_HAS_WSTRING_CONVERSION)
+    set(EXTRA_FLAGS "${EXTRA_FLAGS} -Wstring-conversion")
+  endif()
+endif(NOT MSVC)
 
 if (LIB_PROTO_MUTATOR_WITH_ASAN)
   if (LIB_PROTO_MUTATOR_HAS_SANITIZE_ADDRESS)

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -23,11 +23,20 @@ set(GTEST_MAIN_LIBRARIES gtest_main)
 set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
 
 foreach(lib IN LISTS GTEST_BOTH_LIBRARIES)
-  list(APPEND GTEST_BUILD_BYPRODUCTS ${GTEST_INSTALL_DIR}/lib/lib${lib}.a)
+  if (MSVC)
+    if (CMAKE_BUILD_TYPE MATCHES Debug)
+      set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/${lib}d.lib)
+    else()
+      set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/${lib}.lib)
+    endif()
+  else()
+    set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/lib${lib}.a)
+  endif()
+  list(APPEND GTEST_BUILD_BYPRODUCTS ${LIB_PATH})
 
   add_library(${lib} STATIC IMPORTED)
   set_property(TARGET ${lib} PROPERTY IMPORTED_LOCATION
-               ${GTEST_INSTALL_DIR}/lib/lib${lib}.a)
+               ${LIB_PATH})
   add_dependencies(${lib} ${GTEST_TARGET})
 endforeach(lib)
 

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -30,11 +30,16 @@ ELSE()
 ENDIF()
 
 foreach(lib ${PROTOBUF_LIBRARIES})
-  list(APPEND PROTOBUF_BUILD_BYPRODUCTS ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.a)
+  if (MSVC)
+    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.lib)
+  else()
+    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.a)
+  endif()
+  list(APPEND PROTOBUF_BUILD_BYPRODUCTS ${LIB_PATH})
 
   add_library(${lib} STATIC IMPORTED)
   set_property(TARGET ${lib} PROPERTY IMPORTED_LOCATION
-               ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.a)
+               ${LIB_PATH})
   add_dependencies(${lib} ${PROTOBUF_TARGET})
 endforeach(lib)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,7 +40,16 @@ if (LIB_PROTO_MUTATOR_TESTING)
                         ${ZLIB_LIBRARIES}
                         ${GTEST_BOTH_LIBRARIES}
                         ${CMAKE_THREAD_LIBS_INIT})
+  add_executable(no_mutator_test
+                 no_mutator_test.cc
+                 ${PROTO_SRCS})
+  target_link_libraries(no_mutator_test
+                        protobuf-mutator
+                        protobuf-mutator-libfuzzer
+                        ${GTEST_BOTH_LIBRARIES}
+                        ${CMAKE_THREAD_LIBS_INIT})
 
+  add_test(test.protobuf_no_mutator_test no_mutator_test --gtest_color=yes AUTO)
   ProcessorCount(CPU_COUNT)
   math(EXPR TEST_SHARDS_COUNT 2*${CPU_COUNT})
   math(EXPR TEST_SHARDS_MAX ${TEST_SHARDS_COUNT}-1)

--- a/src/libfuzzer/libfuzzer_mutator.cc
+++ b/src/libfuzzer/libfuzzer_mutator.cc
@@ -22,8 +22,8 @@
 #include "port/protobuf.h"
 #include "src/mutator.h"
 
-// see compiler-rt/lib/sanitizer-common/sanitizer_internal_defs.h; usage of
-// SANITIZER_INTERFACE_WEAK_DEF is the same with some functionality removed
+// see compiler-rt/lib/sanitizer-common/sanitizer_internal_defs.h; usage same as
+// SANITIZER_INTERFACE_WEAK_DEF with some functionality removed
 #ifdef _MSC_VER
 #if defined(_M_IX86) || defined(__i386__)
 #define WIN_SYM_PREFIX "_"
@@ -37,7 +37,7 @@
 #define WEAK_DEFAULT_NAME(Name) Name##__def
 
 // clang-format off
-#define SANITIZER_INTERFACE_WEAK_DEF(ReturnType, Name, ...)   \
+#define LIB_PROTO_MUTATOR_WEAK_DEF(ReturnType, Name, ...)     \
   __pragma(comment(linker, "/alternatename:"                  \
            WIN_SYM_PREFIX STRINGIFY(Name) "="                 \
            WIN_SYM_PREFIX STRINGIFY(WEAK_DEFAULT_NAME(Name))))\
@@ -45,12 +45,11 @@
   extern "C" ReturnType WEAK_DEFAULT_NAME(Name)(__VA_ARGS__)
 // clang-format on
 #else
-#define SANITIZER_INTERFACE_WEAK_DEF(ReturnType, Name, ...) \
+#define LIB_PROTO_MUTATOR_WEAK_DEF(ReturnType, Name, ...) \
   extern "C" __attribute__((weak)) ReturnType Name(__VA_ARGS__)
 #endif
 
-SANITIZER_INTERFACE_WEAK_DEF(size_t, LLVMFuzzerMutate, uint8_t*, size_t,
-                             size_t) {
+LIB_PROTO_MUTATOR_WEAK_DEF(size_t, LLVMFuzzerMutate, uint8_t*, size_t, size_t) {
   return 0;
 }
 

--- a/src/libfuzzer/libfuzzer_mutator.cc
+++ b/src/libfuzzer/libfuzzer_mutator.cc
@@ -22,8 +22,7 @@
 #include "port/protobuf.h"
 #include "src/mutator.h"
 
-extern "C" size_t LLVMFuzzerMutate(uint8_t*, size_t, size_t)
-    __attribute__((weak));
+extern "C" size_t LLVMFuzzerMutate(uint8_t*, size_t, size_t);
 
 namespace protobuf_mutator {
 namespace libfuzzer {

--- a/src/libfuzzer/libfuzzer_mutator.cc
+++ b/src/libfuzzer/libfuzzer_mutator.cc
@@ -22,7 +22,33 @@
 #include "port/protobuf.h"
 #include "src/mutator.h"
 
+#ifdef _MSC_VER
+
+// see compiler-rt/lib/sanitizer-common/sanitizer_internal_defs.h
+# if defined(_M_IX86) || defined(__i386__)
+#  define WIN_SYM_PREFIX "_"
+# else
+#  define WIN_SYM_PREFIX
+# endif
+
+# define STRINGIFY_(A) #A
+# define STRINGIFY(A) STRINGIFY_(A)
+
+# define WIN_WEAK_ALIAS(Name, Default)                                         \
+  __pragma(comment(linker, "/alternatename:" WIN_SYM_PREFIX STRINGIFY(Name) "="\
+                                             WIN_SYM_PREFIX STRINGIFY(Default)))
+
+WIN_WEAK_ALIAS(LLVMFuzzerMutate, LLVMFuzzerMutateDef)
+
+extern "C" size_t LLVMFuzzerMutateDef(uint8_t*, size_t, size_t) { exit(1); }
 extern "C" size_t LLVMFuzzerMutate(uint8_t*, size_t, size_t);
+
+#else
+
+extern "C" size_t LLVMFuzzerMutate(uint8_t*, size_t, size_t)
+  __attribute__((weak));
+
+#endif
 
 namespace protobuf_mutator {
 namespace libfuzzer {

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -260,13 +260,13 @@ class ReducedTestMutator : public TestMutator {
   double MutateDouble(double value) override { return GetRandomValue(); }
   std::string MutateString(const std::string& value,
                            size_t size_increase_hint) override {
-    return strings_[std::uniform_int_distribution<uint8_t>(
+    return strings_[std::uniform_int_distribution<>(
         0, strings_.size() - 1)(*random())];
   }
 
  private:
   float GetRandomValue() {
-    return values_[std::uniform_int_distribution<uint8_t>(
+    return values_[std::uniform_int_distribution<>(
         0, values_.size() - 1)(*random())];
   }
 

--- a/src/no_mutator_test.cc
+++ b/src/no_mutator_test.cc
@@ -1,0 +1,28 @@
+// Copyright 2019 Google Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "port/gtest.h"
+#include "src/libfuzzer/libfuzzer_macro.h"
+#include "src/mutator_test_proto2.pb.h"
+
+static bool reached = false;
+
+DEFINE_PROTO_FUZZER(const protobuf_mutator::EmptyMessage& message) {
+  reached = true;
+}
+
+TEST(NoMutatorTest, Basic) {
+  LLVMFuzzerTestOneInput((const uint8_t*)"", 0);
+  EXPECT_TRUE(reached);
+}

--- a/src/utf8_fix_test.cc
+++ b/src/utf8_fix_test.cc
@@ -45,7 +45,7 @@ INSTANTIATE_TEST_SUITE_P(Size, FixUtf8StringTest, ::testing::Range(0, 10));
 
 TEST_P(FixUtf8StringTest, FixUtf8String) {
   RandomEngine random(GetParam());
-  std::uniform_int_distribution<uint8_t> random8(0, 0xFF);
+  std::uniform_int_distribution<> random8(0, 0xFF);
 
   std::string str(random8(random), 0);
   for (uint32_t run = 0; run < 10000; ++run) {

--- a/src/weighted_reservoir_sampler_test.cc
+++ b/src/weighted_reservoir_sampler_test.cc
@@ -14,6 +14,7 @@
 
 #include "src/weighted_reservoir_sampler.h"
 
+#include <numeric>
 #include <tuple>
 #include <vector>
 


### PR DESCRIPTION
Fixes some issues with compiler flags not supported on MSVC (-Werror)

Also, Protobuf builds by default with [/MT](https://github.com/protocolbuffers/protobuf/blob/d9ccd0c0e6bbda9bf4476088eeb46b02d7dcd327/examples/CMakeLists.txt#L16), whereas LPM built by default
with /MD. Now, when `-DLIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF=On` or
`-DLIB_PROTO_MUTATOR_MSVC_STATIC_RUNTIME=On` are specified we build LPM with
/MT so LPM and Protobuf can properly link together.