### PR TITLE
Add Travis and oss-fuzz badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # libprotobuf-mutator
 
+[![TravisCI Build Status](https://travis-ci.org/google/libprotobuf-mutator.svg?branch=master)](https://travis-ci.org/google/libprotobuf-mutator)
+[![Fuzzing Status](https://oss-fuzz-build-logs.storage.googleapis.com/badges/libprotobuf-mutator.svg)](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#libprotobuf-mutator)
+
 ## Overview
 libprotobuf-mutator is a library to randomly mutate
 [protobuffers](https://github.com/google/protobuf). <BR>


### PR DESCRIPTION
We just added fuzzing status badges in oss-fuzz.

This should provide quick at-a-glance information to make sure that the oss-fuzz build is still successful and the project is being continuously fuzzed.

I also placed the travis build status in the README as well.