### PR TITLE
Apply mutator callbacks to the correct submessage

### DIFF
--- a/src/field_instance.h
+++ b/src/field_instance.h
@@ -328,6 +328,8 @@ class FieldInstance : public ConstFieldInstance {
     if (value) mutable_message->CopyFrom(*value);
   }
 
+  protobuf::Message* message() const { return message_; }
+
  private:
   template <class T>
   void InsertRepeated(const T& value) const {

--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -20,7 +20,6 @@
 #include <string>
 #include <vector>
 
-#include "src/field_instance.h"
 #include "src/utf8_fix.h"
 #include "src/weighted_reservoir_sampler.h"
 

--- a/src/mutator.h
+++ b/src/mutator.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "port/protobuf.h"
+#include "src/field_instance.h"
 #include "src/random.h"
 
 namespace protobuf_mutator {
@@ -95,8 +96,7 @@ class Mutator {
                      protobuf::Message* message2);
   std::string MutateUtf8String(const std::string& value,
                                size_t size_increase_hint);
-  bool ApplyCustomMutations(protobuf::Message* message,
-                            const protobuf::FieldDescriptor* field);
+  bool ApplyCustomMutations(const FieldInstance& field);
   bool keep_initialized_ = true;
   size_t random_to_default_ratio_ = 100;
   RandomEngine random_;


### PR DESCRIPTION
Given a callback registered for a field of a nested message, the current
behavior will incorrectly invoke the callback with the top-level message.
Fix this.