### PR TITLE
Add global mutator support

### DIFF
--- a/src/libfuzzer/libfuzzer_macro.cc
+++ b/src/libfuzzer/libfuzzer_macro.cc
@@ -184,10 +184,11 @@ bool LoadProtoInput(bool binary, const uint8_t* data, size_t size,
                 : ParseTextMessage(data, size, input);
 }
 
-void RegisterPostProcessorImpl(
+void RegisterPostProcessor(
+    const protobuf::Descriptor* desc,
     std::function<void(protobuf::Message* message, unsigned int seed)>
         callback) {
-  GetMutator()->RegisterPostProcessor(callback);
+  GetMutator()->RegisterPostProcessor(desc, callback);
 }
 
 }  // namespace libfuzzer

--- a/src/libfuzzer/libfuzzer_macro.h
+++ b/src/libfuzzer/libfuzzer_macro.h
@@ -106,7 +106,8 @@ size_t CustomProtoCrossOver(bool binary, const uint8_t* data1, size_t size1,
 bool LoadProtoInput(bool binary, const uint8_t* data, size_t size,
                     protobuf::Message* input);
 
-void RegisterPostProcessorImpl(
+void RegisterPostProcessor(
+    const protobuf::Descriptor* desc,
     std::function<void(protobuf::Message* message, unsigned int seed)>
         callback);
 
@@ -114,9 +115,9 @@ template <class Proto>
 struct PostProcessorRegistration {
   PostProcessorRegistration(
       const std::function<void(Proto* message, unsigned int seed)>& callback) {
-    protobuf_mutator::libfuzzer::RegisterPostProcessorImpl(
-        [callback](protobuf_mutator::protobuf::Message* message,
-                   unsigned int seed) {
+    RegisterPostProcessor(
+        Proto::descriptor(),
+        [callback](protobuf::Message* message, unsigned int seed) {
           callback(static_cast<Proto*>(message), seed);
         });
   }

--- a/src/mutator.h
+++ b/src/mutator.h
@@ -70,7 +70,8 @@ class Mutator {
   // Register callback which will be called after every message mutation.
   // In this callback fuzzer may adjust content of the message or mutate some
   // fields in some fuzzer specific way.
-  void RegisterPostProcessor(PostProcess post_process);
+  void RegisterPostProcessor(const protobuf::Descriptor* desc,
+                             PostProcess callback);
 
  protected:
   // TODO(vitalybuka): Consider to replace with single mutate (uint8_t*, size).
@@ -85,6 +86,8 @@ class Mutator {
   virtual std::string MutateString(const std::string& value,
                                    size_t size_increase_hint);
 
+  std::unordered_map<const protobuf::Descriptor*, PostProcess> post_processors_;
+
   RandomEngine* random() { return &random_; }
 
  private:
@@ -96,12 +99,10 @@ class Mutator {
                      protobuf::Message* message2);
   std::string MutateUtf8String(const std::string& value,
                                size_t size_increase_hint);
-  bool ApplyCustomMutations(protobuf::Message* message,
-                            const protobuf::FieldDescriptor* field);
+  void ApplyPostProcessing(protobuf::Message* message);
   bool keep_initialized_ = true;
   size_t random_to_default_ratio_ = 100;
   RandomEngine random_;
-  PostProcess post_process_;
 };
 
 }  // namespace protobuf_mutator

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -593,7 +593,8 @@ TYPED_TEST(MutatorTypedTest, RegisterPostProcessor) {
 
   TestMutator mutator(false);
   mutator.RegisterPostProcessor(
-      [kIndicatorString](protobuf::Message* message, uint32_t seed) {
+      TestFixture::Message::descriptor(),
+      [kIndicatorString](protobuf::Message* message, unsigned int seed) {
         typename TestFixture::Message* test_message =
             static_cast<typename TestFixture::Message*>(message);
         if (seed % 2) test_message->set_optional_string(kIndicatorString);


### PR DESCRIPTION
I have a use-case where multiple top-level proto message embed the same
submessage type.
I would like to be able to create a single mutator for the message type
instead of having to duplicate the logic everywhere.