### PR TITLE
Allow unknown fields in corpus parser

### DIFF
--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -293,9 +293,12 @@ const char kOptionalInDeepAnyFields[] = R"(
   }
 )";
 
-const char kUnknownField[] = R"(
+const char kUnknownFieldInput[] = R"(
   optional_bool: true
   unknown_field: "test unknown field"
+)";
+
+const char kUnknownFieldExpected[] = R"(optional_bool: true
 )";
 
 class TestMutator : public Mutator {
@@ -673,10 +676,10 @@ TYPED_TEST(MutatorTypedTest, Serialization) {
   }
 }
 
-TYPED_TEST(MutatorTypedTest, UnknownSerialization) {
+TYPED_TEST(MutatorTypedTest, UnknownFieldTextFormat) {
   typename TestFixture::Message parsed;
-  EXPECT_TRUE(ParseTextMessage(kUnknownField, &parsed));
-  EXPECT_NE(SaveMessageAsText(parsed), kUnknownField);
+  EXPECT_TRUE(ParseTextMessage(kUnknownFieldInput, &parsed));
+  EXPECT_EQ(SaveMessageAsText(parsed), kUnknownFieldExpected);
 }
 
 TYPED_TEST(MutatorTypedTest, DeepRecursion) {

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -293,6 +293,11 @@ const char kOptionalInDeepAnyFields[] = R"(
   }
 )";
 
+const char kUnknownField[] = R"(
+  optional_bool: true
+  unknown_field: "test unknown field"
+)";
+
 class TestMutator : public Mutator {
  public:
   explicit TestMutator(bool keep_initialized,
@@ -666,6 +671,12 @@ TYPED_TEST(MutatorTypedTest, Serialization) {
       EXPECT_TRUE(MessageDifferencer::Equals(parsed, message));
     }
   }
+}
+
+TYPED_TEST(MutatorTypedTest, UnknownSerialization) {
+  typename TestFixture::Message parsed;
+  EXPECT_TRUE(ParseTextMessage(kUnknownField, &parsed));
+  EXPECT_NE(SaveMessageAsText(parsed), kUnknownField);
 }
 
 TYPED_TEST(MutatorTypedTest, DeepRecursion) {

--- a/src/text_format.cc
+++ b/src/text_format.cc
@@ -30,6 +30,7 @@ bool ParseTextMessage(const std::string& data, protobuf::Message* output) {
   TextFormat::Parser parser;
   parser.SetRecursionLimit(100);
   parser.AllowPartialMessage(true);
+  parser.AllowUnknownField(true);
   if (!parser.ParseFromString(data, output)) {
     output->Clear();
     return false;


### PR DESCRIPTION
As discussed in envoyproxy/envoy#10796, this will allow breaking wire-compatibility changes in the input proto. The pre-existing corpus will still function, but old fields will be ignored.

Risk: Typos in the text proto will cause the fuzzer to run on an incomplete proto. Previously, this would log an error message and skip fuzzing with that test case.

Testing: I'm not sure how to add it to `mutator_test.cc`. I manually tested that unknown text format files will be parsed without `ParseTextMessage` returning false.