### PR TITLE
Temporarily dissable AllowUnknownField

### DIFF
--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -679,7 +679,7 @@ TYPED_TEST(MutatorTypedTest, Serialization) {
 TYPED_TEST(MutatorTypedTest, UnknownFieldTextFormat) {
   typename TestFixture::Message parsed;
   EXPECT_TRUE(ParseTextMessage(kUnknownFieldInput, &parsed));
-  EXPECT_EQ(SaveMessageAsText(parsed), kUnknownFieldExpected);
+  EXPECT_NE(SaveMessageAsText(parsed), kUnknownFieldExpected);
 }
 
 TYPED_TEST(MutatorTypedTest, DeepRecursion) {

--- a/src/text_format.cc
+++ b/src/text_format.cc
@@ -30,7 +30,7 @@ bool ParseTextMessage(const std::string& data, protobuf::Message* output) {
   TextFormat::Parser parser;
   parser.SetRecursionLimit(100);
   parser.AllowPartialMessage(true);
-  parser.AllowUnknownField(true);
+  // parser.AllowUnknownField(true);
   if (!parser.ParseFromString(data, output)) {
     output->Clear();
     return false;


### PR DESCRIPTION
We need to fix AllowUnknownField implementation to respect SetRecursionLimit.
Issue #172