### PR TITLE
Fix unknown fields

### DIFF
--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -679,7 +679,7 @@ TYPED_TEST(MutatorTypedTest, Serialization) {
 TYPED_TEST(MutatorTypedTest, UnknownFieldTextFormat) {
   typename TestFixture::Message parsed;
   EXPECT_TRUE(ParseTextMessage(kUnknownFieldInput, &parsed));
-  EXPECT_NE(SaveMessageAsText(parsed), kUnknownFieldExpected);
+  EXPECT_EQ(SaveMessageAsText(parsed), kUnknownFieldExpected);
 }
 
 TYPED_TEST(MutatorTypedTest, DeepRecursion) {

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -678,7 +678,7 @@ TYPED_TEST(MutatorTypedTest, Serialization) {
 
 TYPED_TEST(MutatorTypedTest, UnknownFieldTextFormat) {
   typename TestFixture::Message parsed;
-  EXPECT_FALSE(ParseTextMessage(kUnknownFieldInput, &parsed));
+  EXPECT_TRUE(ParseTextMessage(kUnknownFieldInput, &parsed));
   EXPECT_NE(SaveMessageAsText(parsed), kUnknownFieldExpected);
 }
 

--- a/src/text_format.cc
+++ b/src/text_format.cc
@@ -30,7 +30,7 @@ bool ParseTextMessage(const std::string& data, protobuf::Message* output) {
   TextFormat::Parser parser;
   parser.SetRecursionLimit(100);
   parser.AllowPartialMessage(true);
-  // parser.AllowUnknownField(true);
+  parser.AllowUnknownField(true);
   if (!parser.ParseFromString(data, output)) {
     output->Clear();
     return false;


### PR DESCRIPTION
The fix to protocol buffers was made in google3 and is now on Github: https://github.com/protocolbuffers/protobuf/commit/c05b55880fc7cf1ed8d118b21266fa4bf9c4cbf7#diff-af8c58a717e41f41544206e37b18de65R640

Is there anything else we need to do so we can update? From my understanding, libprotobufmutator does not use CMake to pull in the repository, it just finds it on the user's path.

Same changes as #170 
Fixes #172