### PR TITLE
Fix building on Fedora

### DIFF
--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(GNUInstallDirs)
+
 set(GTEST_TARGET external.googletest)
 set(GTEST_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/${GTEST_TARGET})
 
@@ -25,12 +27,12 @@ set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
 foreach(lib IN LISTS GTEST_BOTH_LIBRARIES)
   if (MSVC)
     if (CMAKE_BUILD_TYPE MATCHES Debug)
-      set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/${lib}d.lib)
+      set(LIB_PATH ${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${lib}d.lib)
     else()
-      set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/${lib}.lib)
+      set(LIB_PATH ${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${lib}.lib)
     endif()
   else()
-    set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/lib${lib}.a)
+    set(LIB_PATH ${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.a)
   endif()
   list(APPEND GTEST_BUILD_BYPRODUCTS ${LIB_PATH})
 

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(GNUInstallDirs)
+
 # We only need protobuf_generate_cpp from FindProtobuf, and we are going to
 # override the rest with ExternalProject version.
 include (FindProtobuf)
@@ -31,9 +33,9 @@ ENDIF()
 
 foreach(lib ${PROTOBUF_LIBRARIES})
   if (MSVC)
-    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.lib)
+    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.lib)
   else()
-    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.a)
+    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.a)
   endif()
   list(APPEND PROTOBUF_BUILD_BYPRODUCTS ${LIB_PATH})
 


### PR DESCRIPTION
Use https://cmake.org/cmake/help/latest/module/GNUInstallDirs.html
module for determining whether child CMake will install libraries into
lib, lib64 or even somewhere else.

Fixes #131