### PR TITLE
Fix pkgconfig and add CMake targets installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,11 @@ if (NOT "${LIB_PROTO_MUTATOR_FUZZER_LIBRARIES}" STREQUAL "" OR
   add_subdirectory(examples EXCLUDE_FROM_ALL)
 endif()
 
+install(EXPORT libprotobuf-mutatorTargets FILE libprotobuf-mutatorTargets.cmake
+  NAMESPACE libprotobuf-mutator:: DESTINATION lib/cmake/libprotobuf-mutator)
+configure_file(libprotobuf-mutatorConfig.cmake.in libprotobuf-mutatorConfig.cmake @ONLY)
+install(FILES "${CMAKE_CURRENT_BINARY_DIR}/libprotobuf-mutatorConfig.cmake"
+  DESTINATION lib/cmake/libprotobuf-mutator)
 configure_file("libprotobuf-mutator.pc.in" "libprotobuf-mutator.pc" @ONLY)
 install(FILES "${CMAKE_BINARY_DIR}/libprotobuf-mutator.pc"
   DESTINATION ${PKG_CONFIG_PATH})

--- a/libprotobuf-mutator.pc.in
+++ b/libprotobuf-mutator.pc.in
@@ -1,8 +1,9 @@
 prefix=@CMAKE_INSTALL_PREFIX@
+libdir=${prefix}/lib
 includedir=${prefix}/include/libprotobuf-mutator
 
 Name: libprotobuf-mutator
 Description: randomly mutate protobuffers for fuzzing
 Version: 0
 Cflags: -I${includedir} -I${includedir}/src
-Libs: -lprotobuf-mutator-libfuzzer -lprotobuf-mutator
+Libs: -L${libdir} -lprotobuf-mutator-libfuzzer -lprotobuf-mutator

--- a/libprotobuf-mutatorConfig.cmake.in
+++ b/libprotobuf-mutatorConfig.cmake.in
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+
+find_dependency(Protobuf REQUIRED)
+
+include("${CMAKE_CURRENT_LIST_DIR}/libprotobuf-mutatorTargets.cmake")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -60,5 +60,7 @@ if (LIB_PROTO_MUTATOR_TESTING)
 endif()
 
 install(TARGETS protobuf-mutator
+        EXPORT libprotobuf-mutatorTargets
         ARCHIVE DESTINATION ${LIB_DIR}
-        LIBRARY DESTINATION ${LIB_DIR})
+        LIBRARY DESTINATION ${LIB_DIR}
+        INCLUDES DESTINATION include/libprotobuf-mutator include/libprotobuf-mutator/src)

--- a/src/libfuzzer/CMakeLists.txt
+++ b/src/libfuzzer/CMakeLists.txt
@@ -23,8 +23,10 @@ set_target_properties(protobuf-mutator-libfuzzer PROPERTIES
                       SOVERSION 0)
 
 install(TARGETS protobuf-mutator-libfuzzer
+        EXPORT libprotobuf-mutatorTargets
         ARCHIVE DESTINATION ${LIB_DIR}
-        LIBRARY DESTINATION ${LIB_DIR})
+        LIBRARY DESTINATION ${LIB_DIR}
+        INCLUDES DESTINATION include/libprotobuf-mutator include/libprotobuf-mutator/src)
 
 if (LIB_PROTO_MUTATOR_TESTING)
   add_executable(libfuzzer_test


### PR DESCRIPTION
- Fix pkgconfig to contain the library link directory flag
- Add CMake targets installation. Usage:
```
    find_package(libprotobuf-mutator CONFIG REQUIRED)
    target_link_libraries(main PRIVATE libprotobuf-mutator::protobuf-mutator libprotobuf-mutator::protobuf-mutator-libfuzzer)
```