### PR TITLE
Fix CI

### DIFF
--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GNUInstallDirs)
-
 set(GTEST_TARGET external.googletest)
 set(GTEST_INSTALL_DIR ${CMAKE_CURRENT_BINARY_DIR}/${GTEST_TARGET})
 
@@ -27,12 +25,12 @@ set(GTEST_BOTH_LIBRARIES ${GTEST_LIBRARIES} ${GTEST_MAIN_LIBRARIES})
 foreach(lib IN LISTS GTEST_BOTH_LIBRARIES)
   if (MSVC)
     if (CMAKE_BUILD_TYPE MATCHES Debug)
-      set(LIB_PATH ${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${lib}d.lib)
+      set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/${lib}d.lib)
     else()
-      set(LIB_PATH ${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/${lib}.lib)
+      set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/${lib}.lib)
     endif()
   else()
-    set(LIB_PATH ${GTEST_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.a)
+    set(LIB_PATH ${GTEST_INSTALL_DIR}/lib/lib${lib}.a)
   endif()
   list(APPEND GTEST_BUILD_BYPRODUCTS ${LIB_PATH})
 
@@ -52,5 +50,6 @@ ExternalProject_Add(${GTEST_TARGET}
                      -DCMAKE_CXX_COMPILER:FILEPATH=${CMAKE_CXX_COMPILER}
     CMAKE_ARGS ${CMAKE_ARGS}
                -DCMAKE_INSTALL_PREFIX=${GTEST_INSTALL_DIR}
+               -DCMAKE_INSTALL_LIBDIR=lib
     BUILD_BYPRODUCTS ${GTEST_BUILD_BYPRODUCTS}
 )

--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include(GNUInstallDirs)
-
 # We only need protobuf_generate_cpp from FindProtobuf, and we are going to
 # override the rest with ExternalProject version.
 include (FindProtobuf)
@@ -33,9 +31,9 @@ ENDIF()
 
 foreach(lib ${PROTOBUF_LIBRARIES})
   if (MSVC)
-    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.lib)
+    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.lib)
   else()
-    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/${CMAKE_INSTALL_LIBDIR}/lib${lib}.a)
+    set(LIB_PATH ${PROTOBUF_INSTALL_DIR}/lib/lib${lib}.a)
   endif()
   list(APPEND PROTOBUF_BUILD_BYPRODUCTS ${LIB_PATH})
 
@@ -70,6 +68,7 @@ ExternalProject_Add(${PROTOBUF_TARGET}
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${PROTOBUF_INSTALL_DIR}/src/${PROTOBUF_TARGET}/cmake
         -G${CMAKE_GENERATOR}
         -DCMAKE_INSTALL_PREFIX=${PROTOBUF_INSTALL_DIR}
+        -DCMAKE_INSTALL_LIBDIR=lib
         -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
         -DCMAKE_POSITION_INDEPENDENT_CODE=ON
         -DCMAKE_C_COMPILER:FILEPATH=${CMAKE_C_COMPILER}


### PR DESCRIPTION
Commit 918dafea39ec ("Fix building on Fedora") introduced usage
of CMAKE_INSTALL_LIBDIR in order to predict where gtest and
libprotobuf will put their libraries. Unfortunately, the value of this
variable depends on the value of CMAKE_INSTALL_PREFIX, specifically,
whether it points to /usr.

CI uses precisely -DCMAKE_INSTALL_PREFIX=/usr and was therefore broken
by this change.

In order to fix CI and keep Fedora working, just ask gtest and
libprotobuf to put their libraries into "lib".