### PR TITLE
force libxml2 to use static lib

### DIFF
--- a/cmake/external/libxml2.cmake
+++ b/cmake/external/libxml2.cmake
@@ -42,6 +42,7 @@ ExternalProject_Add(${LIBXML2_TARGET}
                                                     CXX=${CMAKE_CXX_COMPILER}
                                                     CFLAGS=${LIBXML2_CFLAGS}
                                                     CXXFLAGS=${LIBXML2_CXXFLAGS}
+                                                    --enable-shared=no
     BUILD_COMMAND make -j ${CPU_COUNT} all
     INSTALL_COMMAND make install
     BUILD_BYPRODUCTS ${LIBXML2_BUILD_BYPRODUCTS}


### PR DESCRIPTION
ninja check was complaining about the libxml2.a file not found. See [issue 204](https://github.com/google/libprotobuf-mutator/issues/204). The default ./configure script for libxml2 generates a shared library, so we generate a static library instead.