### PR TITLE
Add newline in libfuzzer_macro header so it does not error via clang-…

### DIFF
--- a/src/libfuzzer/libfuzzer_macro.h
+++ b/src/libfuzzer/libfuzzer_macro.h
@@ -141,3 +141,4 @@ struct GetFirstParam<void (*)(Arg)> {
 }  // namespace protobuf_mutator
 
 #endif  // SRC_LIBFUZZER_LIBFUZZER_MACRO_H_
+


### PR DESCRIPTION
…14 -Wnewline-eof

Reason for PR is failing build of solidity that depends on LPM: See https://oss-fuzz-build-logs.storage.googleapis.com/log-341bacc5-2a94-4268-a42e-19a7c797fcc7.txt