### PR TITLE
Fix undefined reference to ~InternalMetadata()

### DIFF
--- a/cmake/external/protobuf.cmake
+++ b/cmake/external/protobuf.cmake
@@ -64,6 +64,7 @@ ExternalProject_Add(${PROTOBUF_TARGET}
     PREFIX ${PROTOBUF_TARGET}
     GIT_REPOSITORY https://github.com/google/protobuf.git
     GIT_TAG v3.20.1
+    PATCH_COMMAND git cherry-pick 0574167d92a2
     UPDATE_COMMAND ""
     CONFIGURE_COMMAND ${CMAKE_COMMAND} ${PROTOBUF_INSTALL_DIR}/src/${PROTOBUF_TARGET}/cmake
         -G${CMAKE_GENERATOR}


### PR DESCRIPTION
Hi!

I'm seeing linker failures when trying to link with the latest libprotobuf-mutator on s390x.
Cherry-picking the corresponding protobuf fix makes them go away.
Unfortunately the fix is not yet a part of any tag, otherwise I would've suggested updating that.

Best regards,
Ilya