### PR TITLE
Add support for rejecting invalid inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,38 @@ DEFINE_PROTO_FUZZER(const MyMessageType& input) {
 
 Please see [libfuzzer_example.cc](/examples/libfuzzer/libfuzzer_example.cc) as an example.
 
+### Reject unwanted inputs
+To reject adding unwanted inputs in corpus:
+
+Either define `LIBPROTOBUFMUTATOR_ENABLE_RETURN_CODE` macro in your code and return `-1` for inputs to be rejected:
+
+```
+#define LIBPROTOBUFMUTATOR_ENABLE_RETURN_CODE
+#include "src/libfuzzer/libfuzzer_macro.h"
+
+DEFINE_PROTO_FUZZER(const MyMessageType& input) {
+  // Code which needs to be fuzzed.
+  ConsumeMyMessageType(input);
+  // If 'input' is to be rejected
+  return -1;
+}
+```
+
+or use another macro `DEFINE_PROTO_FUZZER_RET` supporting return code:
+
+```
+#include "src/libfuzzer/libfuzzer_macro.h"
+
+DEFINE_PROTO_FUZZER_RET(const MyMessageType& input) {
+  // Code which needs to be fuzzed.
+  ConsumeMyMessageType(input);
+  // If 'input' is to be rejected
+  return -1;
+}
+```
+
+Refer https://llvm.org/docs/LibFuzzer.html#rejecting-unwanted-inputs for details.
+
 ### Mutation post-processing (experimental)
 Sometimes it's necessary to keep particular values in some fields without which the proto
 is going to be rejected by fuzzed code. E.g. code may expect consistency between some fields

--- a/src/libfuzzer/CMakeLists.txt
+++ b/src/libfuzzer/CMakeLists.txt
@@ -29,14 +29,20 @@ install(TARGETS protobuf-mutator-libfuzzer
         INCLUDES DESTINATION include/libprotobuf-mutator include/libprotobuf-mutator/src)
 
 if (LIB_PROTO_MUTATOR_TESTING)
-  add_executable(libfuzzer_test
-                 libfuzzer_test.cc)
-  target_link_libraries(libfuzzer_test
-                        protobuf-mutator
-                        protobuf-mutator-libfuzzer
-                        mutator-test-proto
-                        ${GTEST_BOTH_LIBRARIES}
-                        ${CMAKE_THREAD_LIBS_INIT})
-  add_test(test.protobuf_libfuzzer_test libfuzzer_test --gtest_color=yes AUTO)
-  add_dependencies(check libfuzzer_test)
+  list(APPEND TARGETS libfuzzer_test libfuzzer_return_enabled_test libfuzzer_return_overload_test)
+  list(APPEND FLAGS "" LIBPROTOBUFMUTATOR_ENABLE_RETURN_CODE TEST_RETURN_OVERLOAD)
+
+  foreach(TARGET FLAG IN ZIP_LISTS TARGETS FLAGS)
+      add_executable(${TARGET}
+                     libfuzzer_test.cc)
+      target_compile_definitions(${TARGET} PRIVATE ${FLAG})
+      target_link_libraries(${TARGET}
+                            protobuf-mutator
+                            protobuf-mutator-libfuzzer
+                            mutator-test-proto
+                            ${GTEST_BOTH_LIBRARIES}
+                            ${CMAKE_THREAD_LIBS_INIT})
+      add_test(test.protobuf_${TARGET} ${TARGET} --gtest_color=yes AUTO)
+      add_dependencies(check ${TARGET})
+  endforeach()
 endif()


### PR DESCRIPTION
Adds support to reject storing invalid inputs in corpus. There is an ongoing [discussion](https://github.com/google/libprotobuf-mutator/issues/214) about how to support this while preserving backward compatibility.

This PR adds two ways to reject invalid inputs:
1. Defining `LIBPROTOBUFMUTATOR_ENABLE_RETURN_CODE` via the build system or `#define`ing it before including `libfuzzer_macro.h`.
2. Using the `DEFINE_PROTO_FUZZER_RET` macro instead of `DEFINE_PROTO_FUZZER`.