### PR TITLE
Fix default PKG_CONFIG_PATH in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(LIB_PROTO_MUTATOR_TESTING "Enable test building" ON)
 option(LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF
        "Automatically download working protobuf" OFF)
 option(LIB_PROTO_MUTATOR_WITH_ASAN "Enable address sanitizer" OFF)
-option(PKG_CONFIG_PATH "Directory to install pkgconfig file" "share/pkgconfig")
+set(PKG_CONFIG_PATH "share/pkgconfig" CACHE STRING "Directory to install pkgconfig file")
 set(LIB_PROTO_MUTATOR_FUZZER_LIBRARIES "" CACHE STRING "Fuzzing engine libs")
 
 # External dependencies


### PR DESCRIPTION
Since `option()` was used it defaulted to OFF instead of the supplied string as `option()` is used for booleans only, resulting in `libprotobuf-mutator.pc` file being installed in `${prefix}/OFF/libprotobuf-mutator.pc` which is clearly undesirable. Change it to `set()` so the default value is properly stored and used.