### PR TITLE
Include header fixes.

### DIFF
--- a/src/utf8_fix.cc
+++ b/src/utf8_fix.cc
@@ -14,6 +14,8 @@
 
 #include "src/utf8_fix.h"
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <cassert>
 


### PR DESCRIPTION
stdint.h is necessary for uint8_t.