### PR TITLE
Enable CI for non-master branches

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -4,9 +4,7 @@ name: CMake on multiple platforms
 
 on:
   push:
-    branches: [ "master" ]
   pull_request:
-    branches: [ "master" ]
   schedule:
     - cron: '0 2 * * 5'  # Every Friday at 2am
 


### PR DESCRIPTION
This eases development in fork repositories, in particular :pray: 

CC @vitalybuka 
