### PR TITLE
Add support for Ubuntu 20.04 LTS (where OSS-Fuzz is at)

### DIFF
--- a/.github/workflows/cmake-multi-platform.yml
+++ b/.github/workflows/cmake-multi-platform.yml
@@ -40,6 +40,16 @@ jobs:
             c_compiler: clang
             cpp_compiler: clang++
             bundled_protobuf: 'OFF'
+          - os: ubuntu-20.04
+            build_type: Release
+            c_compiler: clang-12
+            cpp_compiler: clang++-12
+            bundled_protobuf: 'OFF'
+          - os: ubuntu-20.04
+            build_type: Debug
+            c_compiler: clang-12
+            cpp_compiler: clang++-12
+            bundled_protobuf: 'OFF'
 
     steps:
     - uses: actions/checkout@v3

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ if (MSVC)
   endif (LIB_PROTO_MUTATOR_DOWNLOAD_PROTOBUF OR LIB_PROTO_MUTATOR_MSVC_STATIC_RUNTIME)
 endif (MSVC)
 
+if (CMAKE_CXX_COMPILER_ID STREQUAL Clang AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 12)
+    message(SEND_ERROR "Clang/libFuzzer >=12.0.0 is needed but you are using ${CMAKE_CXX_COMPILER_VERSION}, please fix.")
+endif()
+
 set(CMAKE_REQUIRED_FLAGS "-fsanitize=address")
 check_cxx_compiler_flag(-fsanitize=address LIB_PROTO_MUTATOR_HAS_SANITIZE_ADDRESS)
 check_cxx_compiler_flag("-fsanitize=address -fsanitize-address-use-after-scope"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,11 @@ add_subdirectory(src)
 
 if (LIB_PROTO_MUTATOR_EXAMPLES AND (NOT "${LIB_PROTO_MUTATOR_FUZZER_LIBRARIES}" STREQUAL "" OR
                                     NOT "${FUZZING_FLAGS}" STREQUAL ""))
+  # NOTE: We need the maximum from:
+  # - CMake >=3.10 for libexpat 2.6.4
+  # - CMake >=3.13 for GoogleTest 1.15.0
+  # - CMake >=3.18 for libxml2 2.13.6
+  cmake_minimum_required(VERSION 3.18)
   add_subdirectory(examples EXCLUDE_FROM_ALL)
 endif()
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ libprotobuf-mutator is a library to randomly mutate
 [protobuffers](https://github.com/google/protobuf). <BR>
 It could be used together with guided fuzzing engines, such as [libFuzzer](http://libfuzzer.info).
 
+The core of libprotobuf-mutator has the following dependencies:
+
+- Protobuf >=3.6.1.3 (library and compiler)
+- Clang >=12.0.0 including libFuzzer
+
 ## Quick start on Debian/Ubuntu
 
 Install prerequisites:

--- a/examples/fuzzer_test.h
+++ b/examples/fuzzer_test.h
@@ -40,6 +40,7 @@ class FuzzerTest : public testing::Test {
   int RunFuzzer(const std::string& name, int max_len, int runs) {
     std::string cmd = "ASAN_OPTIONS=detect_leaks=0 ./" + name;
     cmd += " -seed=9";
+    cmd += " -print_final_stats=1";
     cmd += " -detect_leaks=0";
     cmd += " -len_control=0";
     cmd += " -max_len=" + std::to_string(max_len);

--- a/examples/fuzzer_test.h
+++ b/examples/fuzzer_test.h
@@ -39,6 +39,7 @@ class FuzzerTest : public testing::Test {
 
   int RunFuzzer(const std::string& name, int max_len, int runs) {
     std::string cmd = "ASAN_OPTIONS=detect_leaks=0 ./" + name;
+    cmd += " -seed=9";
     cmd += " -detect_leaks=0";
     cmd += " -len_control=0";
     cmd += " -max_len=" + std::to_string(max_len);

--- a/examples/libfuzzer/libfuzzer_example_test.cc
+++ b/examples/libfuzzer/libfuzzer_example_test.cc
@@ -25,12 +25,12 @@ int GetError(int exit_code) { return WSTOPSIG(exit_code); }
 
 TEST_F(LibFuzzerExampleTest, Text) {
   EXPECT_EQ(kDefaultLibFuzzerError,
-            GetError(RunFuzzer("libfuzzer_example", 1000, 10000000)));
+            GetError(RunFuzzer("libfuzzer_example", 1000, 100000)));
 }
 
 TEST_F(LibFuzzerExampleTest, Binary) {
   EXPECT_EQ(kDefaultLibFuzzerError,
-            GetError(RunFuzzer("libfuzzer_bin_example", 1000, 10000000)));
+            GetError(RunFuzzer("libfuzzer_bin_example", 1000, 100000)));
 }
 
 }  // namespace

--- a/port/protobuf.h
+++ b/port/protobuf.h
@@ -20,16 +20,14 @@
 #include "google/protobuf/any.pb.h"
 #include "google/protobuf/descriptor.pb.h"
 #include "google/protobuf/message.h"
+#include "google/protobuf/stubs/common.h"  // for GOOGLE_PROTOBUF_VERSION
 #include "google/protobuf/text_format.h"
 #include "google/protobuf/util/message_differencer.h"
 #include "google/protobuf/wire_format.h"
 
-// clang-format off
-#include "google/protobuf/port_def.inc"  // MUST be last header included
-// clang-format on
 namespace google {
 namespace protobuf {
-#if PROTOBUF_VERSION < 4025000
+#if GOOGLE_PROTOBUF_VERSION < 4025000
 
 template <typename T>
 const T* DownCastMessage(const Message* message) {
@@ -42,7 +40,7 @@ T* DownCastMessage(Message* message) {
   return const_cast<T*>(DownCastMessage<T>(message_const));
 }
 
-#elif PROTOBUF_VERSION < 5029000
+#elif GOOGLE_PROTOBUF_VERSION < 5029000
 
 template <typename T>
 const T* DownCastMessage(const Message* message) {
@@ -54,11 +52,9 @@ T* DownCastMessage(Message* message) {
   return DownCastToGenerated<T>(message);
 }
 
-#endif  // PROTOBUF_VERSION
+#endif  // GOOGLE_PROTOBUF_VERSION
 }  // namespace protobuf
 }  // namespace google
-#include "google/protobuf/port_undef.inc"
-
 
 namespace protobuf_mutator {
 

--- a/src/field_instance.h
+++ b/src/field_instance.h
@@ -191,7 +191,7 @@ class ConstFieldInstance {
   }
 
   bool EnforceUtf8() const {
-#if PROTOBUF_VERSION >= 4022000  // v3(!).22.0 (commit d85c9944c55fb38f4eae149979a0f680ea125ecb) for requires_utf8_validation
+#if GOOGLE_PROTOBUF_VERSION >= 4022000  // v3(!).22.0 (commit d85c9944c55fb38f4eae149979a0f680ea125ecb) for requires_utf8_validation
     return descriptor_->requires_utf8_validation();
 #else
     return descriptor_->type() == protobuf::FieldDescriptor::TYPE_STRING &&

--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -87,7 +87,17 @@ bool GetRandomBool(RandomEngine* random, size_t n = 2) {
 }
 
 bool IsProto3SimpleField(const FieldDescriptor& field) {
-  return !field.is_repeated() && !field.has_presence();
+#if GOOGLE_PROTOBUF_VERSION >= 3012000 // commit bb30225f06c36399757dc698b409d5f79738e8d1 of >=3.12.0
+  const bool has_presence = field.has_presence();
+#else
+  // NOTE: This mimics Protobuf 3.21.12 ("3021012")
+  const bool has_presence = ! field.is_repeated() && (
+    field.cpp_type() == FieldDescriptor::CppType::CPPTYPE_MESSAGE
+    || field.containing_oneof()
+    || field.file()->syntax() == FileDescriptor::SYNTAX_PROTO2
+  );
+#endif
+  return !field.is_repeated() && !has_presence;
 }
 
 struct CreateDefaultField : public FieldFunction<CreateDefaultField> {

--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -390,13 +390,23 @@ std::unique_ptr<Message> UnpackAny(const Any& any) {
 }
 
 const Any* CastToAny(const Message* message) {
-  return Any::GetDescriptor() == message->GetDescriptor()
+#if GOOGLE_PROTOBUF_VERSION >= 3008000  // commit 1467e08d7c26a7087e5e5b14a4ab2755926e7249 of >=3.8.0
+  const Descriptor* any_descriptor = Any::GetDescriptor();
+#else
+  const Descriptor* any_descriptor = Any::descriptor();
+#endif
+  return any_descriptor == message->GetDescriptor()
              ? protobuf::DownCastMessage<Any>(message)
              : nullptr;
 }
 
 Any* CastToAny(Message* message) {
-  return Any::GetDescriptor() == message->GetDescriptor()
+#if GOOGLE_PROTOBUF_VERSION >= 3008000  // commit 1467e08d7c26a7087e5e5b14a4ab2755926e7249 of >=3.8.0
+  const Descriptor* any_descriptor = Any::GetDescriptor();
+#else
+  const Descriptor* any_descriptor = Any::descriptor();
+#endif
+  return any_descriptor == message->GetDescriptor()
              ? protobuf::DownCastMessage<Any>(message)
              : nullptr;
 }

--- a/src/mutator_test.cc
+++ b/src/mutator_test.cc
@@ -678,12 +678,23 @@ TYPED_TEST(MutatorTypedTest, Serialization) {
 }
 
 TYPED_TEST(MutatorTypedTest, UnknownFieldTextFormat) {
+  // NOTE: This test has little chance of passing when method
+  //       TextFormat::Parser::AllowUnknownField is not available
+#if GOOGLE_PROTOBUF_VERSION >= 3008000  // commit 176f7db11d8242b36a3ea6abb1cc436fca5bf75d of >=3.8.0
   typename TestFixture::Message parsed;
   EXPECT_TRUE(ParseTextMessage(kUnknownFieldInput, &parsed));
   EXPECT_EQ(SaveMessageAsText(parsed), kUnknownFieldExpected);
+#else
+  (void)kUnknownFieldExpected;
+  (void)kUnknownFieldInput;
+  GTEST_SKIP();
+#endif  // GOOGLE_PROTOBUF_VERSION
 }
 
 TYPED_TEST(MutatorTypedTest, DeepRecursion) {
+  // NOTE: This test has little chance of passing when method
+  //       TextFormat::Parser::SetRecursionLimit is not available
+#if GOOGLE_PROTOBUF_VERSION >= 3008000  // commit d8c2501b43c1b56e3efa74048a18f8ce06ba07fe of >=3.8.0
   typename TestFixture::Message message;
   typename TestFixture::Message* last = &message;
   for (int i = 0; i < 150; ++i) {
@@ -695,6 +706,9 @@ TYPED_TEST(MutatorTypedTest, DeepRecursion) {
     EXPECT_EQ(i < 100,
               ParseBinaryMessage(SaveMessageAsBinary(message), &parsed));
   }
+#else
+  GTEST_SKIP();
+#endif  // GOOGLE_PROTOBUF_VERSION
 }
 
 TYPED_TEST(MutatorTypedTest, EmptyMessage) {

--- a/src/text_format.cc
+++ b/src/text_format.cc
@@ -28,9 +28,13 @@ bool ParseTextMessage(const uint8_t* data, size_t size, Message* output) {
 bool ParseTextMessage(const std::string& data, protobuf::Message* output) {
   output->Clear();
   TextFormat::Parser parser;
+#if GOOGLE_PROTOBUF_VERSION >= 3008000  // commit d8c2501b43c1b56e3efa74048a18f8ce06ba07fe of >=3.8.0
   parser.SetRecursionLimit(100);
+#endif
   parser.AllowPartialMessage(true);
+#if GOOGLE_PROTOBUF_VERSION >= 3008000  // commit 176f7db11d8242b36a3ea6abb1cc436fca5bf75d of >=3.8.0
   parser.AllowUnknownField(true);
+#endif
   if (!parser.ParseFromString(data, output)) {
     output->Clear();
     return false;


### PR DESCRIPTION
[OSS-Fuzz is using Ubuntu 20.04](https://github.com/google/oss-fuzz/issues/13016). This pull request will help unlock use of libprotobuf-mutator in OSS-Fuzz with system Protobuf (i.e. of Ubuntu >=20.04) and eventually allow re-enabling compilation of libexpat upstream fuzzer `xml_lpm_fuzzer` that pull request https://github.com/libexpat/libexpat/pull/955 had to disable for a chance at a successful build in OSS-Fuzz. Thank you! :pray: 

CC @vitalybuka 