### PR TITLE
Use `std::move` in two more places?

### DIFF
--- a/src/libfuzzer/libfuzzer_macro.cc
+++ b/src/libfuzzer/libfuzzer_macro.cc
@@ -235,7 +235,7 @@ void RegisterPostProcessor(
     const protobuf::Descriptor* desc,
     std::function<void(protobuf::Message* message, unsigned int seed)>
         callback) {
-  GetMutator()->RegisterPostProcessor(desc, callback);
+  GetMutator()->RegisterPostProcessor(desc, std::move(callback));
 }
 
 }  // namespace libfuzzer

--- a/src/mutator.cc
+++ b/src/mutator.cc
@@ -482,7 +482,7 @@ class PostProcessing {
           Run(It->second.get(), max_depth);
           std::string value;
           It->second->SerializePartialToString(&value);
-          *any->mutable_value() = value;
+          *any->mutable_value() = std::move(value);
         }
       }
     }


### PR DESCRIPTION
As suggested to me by Coverity Scan. It's the only two suggestions it had about libprotobuf-mutator code, as part of a larger scan on libexpat…

@vitalybuka please review carefully, you know modern C++ better than I do. Thanks! :pray: 

