### PR TITLE
build: Add/fix remaining bazel/bzlmod boilerplate

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,0 +1,27 @@
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+licenses(["notice"])  # Apache 2
+
+cc_library(
+    name = "protobuf-mutator",
+    srcs = glob(
+        [
+            "src/**/*.cc",
+        ],
+        exclude = ["**/*_test.cc"],
+    ),
+    hdrs = glob(["src/**/*.h"]) + ["port/protobuf.h"],
+    include_prefix = "libprotobuf_mutator",
+    includes = [
+        "port",
+        "src",
+    ],
+    visibility = ["//visibility:public"],
+    deps = ["@com_google_protobuf//:protobuf"],
+)
+
+alias(
+    name = "libprotobuf-mutator",
+    actual = ":protobuf-mutator",
+    visibility = ["//visibility:public"],
+)

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -9,3 +9,4 @@ bazel_dep(
     version = "26.0.bcr.1",
     repo_name = "com_google_protobuf",
 )
+bazel_dep(name = "rules_cc", version = "0.1.5")


### PR DESCRIPTION
this removes the need for patches in BCR, and allows bazel users to build directly from the repo if they want to build from specific commit, without having to patch in the boilerplate.